### PR TITLE
Update odbc to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-ibmi",
-  "version": "0.0.0",
+  "version": "1.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -426,11 +426,6 @@
         "dom-serializer": "0",
         "domelementtype": "1"
       }
-    },
-    "dotenv": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -1690,9 +1685,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-addon-api": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
-      "integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -1788,12 +1783,19 @@
       }
     },
     "odbc": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/odbc/-/odbc-2.0.0-beta.1.tgz",
-      "integrity": "sha512-2iOfAsOkra5486CVhqgZxV26jn9xlfpAHgSNFUaNr36JKQNaZyR23qW5XdPDBkC/aaQiE8APUZfzl7/Z7V6Tqw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/odbc/-/odbc-2.1.2.tgz",
+      "integrity": "sha512-i6y3gBv363FWY+fDhmvV8q3M/ioVBA9pJZE0jWF1aUf0EWs4rsejaHtWdX+lgfGq24afBpHD5ERLduzMyaFAYA==",
       "requires": {
-        "dotenv": "^6.2.0",
-        "node-addon-api": "^1.3.0"
+        "async": "^3.0.1",
+        "node-addon-api": "^1.7.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+          "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
+        }
       }
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "^1.5.0",
     "debug": "^2.2.0",
     "loopback-connector": "^4.0.0",
-    "odbc": "^2.0.0-beta.1",
+    "odbc": "^2.1.2",
     "strong-globalize": "^2.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Underlying ODBC connector is out of date. Updated to the latest version (2.1.2), which is now out of beta.

#### Related issues

None

### Checklist

- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
