### PR TITLE
fix format issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ schema         | String  | Specifies the default schema name that is used to qua
 Alternatively, you can create and configure the data source in JavaScript code.
 For example:
 
-```JavaScript
+```javascript
 var DataSource = require('loopback-datasource-juggler').DataSource;
 var DB2 = require('loopback-connector-ibmi');
 


### PR DESCRIPTION
### Description

In the connector page https://loopback.io/doc/en/lb4/DB2-for-i-connector.html, the code block towards the end of the page wasn't showing up properly, see screen shot below: 

![Screen Shot 2020-08-06 at 10 53 39 PM](https://user-images.githubusercontent.com/25489897/89603765-c6e63d00-d837-11ea-9ec5-2036e5fb7070.png)



### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
